### PR TITLE
Fixed bug with cipher only returning ASCII values. Needed an extra set

### DIFF
--- a/app/src/main/java/edu/umbc/dmutlu1/caesarcipher/ShiftCipher.java
+++ b/app/src/main/java/edu/umbc/dmutlu1/caesarcipher/ShiftCipher.java
@@ -17,10 +17,10 @@ public class ShiftCipher
             {
                 if (Character.isUpperCase(i))
                 {
-                    encryptedMsg.append((char) ((i - 65 + key) % 26) + 65); //65 is A in ASCII
+                    encryptedMsg.append((char) (((i - 65 + key) % 26) + 65)); //65 is A in ASCII
                 } else
                 {
-                    encryptedMsg.append((char) ((i - 97 + key) % 26) + 97);
+                    encryptedMsg.append((char) (((i - 97 + key) % 26) + 97));
                 } //97 is a in ASCII
 
             } else


### PR DESCRIPTION
of parentheses.

Signed-off-by: dmutlu <devin.mutlu+github@gmail.com>